### PR TITLE
Fix alias in Install-ModuleFast

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -43,6 +43,7 @@ function Install-ModuleFast {
     #The module(s) to install. This can be a string, a ModuleSpecification, a hashtable with nuget version style (e.g. @{Name='test';Version='1.0'}), a hashtable with ModuleSpecification style (e.g. @{Name='test';RequiredVersion='1.0'}),
     [Alias('Name')]
     [Alias('ModuleToInstall')]
+    [Alias('ModulesToInstall')]
     [AllowNull()]
     [AllowEmptyCollection()]
     [Parameter(Mandatory, Position = 0, ValueFromPipeline, ParameterSetName = 'Specification')][ModuleFastSpec[]]$Specification,


### PR DESCRIPTION
In the current release (that the bit.ly-link points at) the now parameter `Specification` was called `ModulesToInstall` (plural), it was then renamed to `ModuleToInstall` (singylar) and now finally it is called `Specification`.

See blame:
https://github.com/JustinGrote/ModuleFast/blame/13f7890a076fc4df1ccea5b3a1a8ae1537ecb2f7/ModuleFast.psm1#L73C6-L73C22

This PR adds an alias to also handle the older parameter name `ModulesToInstall`.