### PR TITLE
🎉 Incomplete Module Handling

### DIFF
--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -605,4 +605,13 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     | Should -Be 'prerelease' -Because 'CI lock file should have 0.1 prerelease even if 0.2 is available'
     #TODO: CI Content
   }
+
+  It 'Handles an incomplete installation' {
+    $incompleteItemPath = "$installTempPath\PreReleaseTest\0.0.1\.incomplete"
+    Install-ModuleFast @imfParams -Specification 'PreReleaseTest=0.0.1'
+    New-Item -ItemType File -Path $incompleteItemPath
+    Install-ModuleFast @imfParams -Specification 'PreReleaseTest=0.0.1' -Update -WarningVariable actual 3>$null
+    $actual | Should -BeLike '*incomplete installation detected*'
+    Test-Path $incompleteItemPath | Should -BeFalse
+  }
 }

--- a/requires.lock.json
+++ b/requires.lock.json
@@ -1,0 +1,3 @@
+{
+  "PrereleaseTest": "0.0.1"
+}


### PR DESCRIPTION
ModuleFast will now detect if a module was potentially not fully installed and reinstall it. This is done by placing a .incomplete file in install-in-progress folders and checking for it before initiating installations and clearing the folder if it is found.