### PR TITLE
✨ Add -DestinationOnly switch

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -1001,7 +1001,12 @@ function Install-ModuleFastHelper {
   CLEAN {
     $cancelTokenSource.Dispose()
     if ($installJobs) {
-      $installJobs | Remove-Job -Force
+      try {
+        $installJobs | Remove-Job -Force -ErrorAction SilentlyContinue
+      } catch {
+        #Suppress this error because it is likely that the job was already removed
+        if ($PSItem -notlike '*because it is a child job*') {throw}
+      }
     }
   }
 }
@@ -1693,7 +1698,7 @@ function Find-LocalModule {
             $manifestCandidate.ModuleVersion -gt $bestCandidate.Value[$moduleSpec].ModuleVersion
           ) {
             Write-Debug "${ModuleSpec}: ⬆️ New Best Candidate Version $($manifestCandidate.ModuleVersion)"
-            $BestCandidate.Value.Add($moduleSpec, $manifestCandidate)
+            $BestCandidate.Value[$moduleSpec] = $manifestCandidate
           }
           continue
         }

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -478,6 +478,7 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     Install-ModuleFast @imfParams 'Az.Compute', 'Az.CosmosDB' -Update -Plan
     | Should -BeNullOrEmpty
   }
+
   It 'Updates if multiple local versions installed' {
     Install-ModuleFast @imfParams 'Plaster=1.1.1'
     Install-ModuleFast @imfParams 'Plaster=1.1.3'
@@ -518,6 +519,24 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
 		| Select-Object -First 1
 		| Should -BeGreaterThan ([version]'5.0.0')
   }
+
+  It 'Detects module in other psmodulePath' {
+    $installPath2 = Join-Path $testdrive $(New-Guid)
+    New-Item -ItemType Directory $installPath2 | Out-Null
+    $env:PSModulePath = "$installPath2"
+    Install-ModuleFast @imfParams -Destination $installPath2 'PreReleaseTest'
+    Install-ModuleFast @imfParams 'PreReleaseTest' -PassThru | Should -BeNullOrEmpty
+  }
+
+  It 'Only considers destination modules if -DestinationOnly is specified' {
+    $installPath2 = Join-Path $testdrive $(New-Guid)
+    New-Item -ItemType Directory $installPath2 | Out-Null
+    $env:PSModulePath = "$installPath2"
+    Install-ModuleFast @imfParams -Destination $installPath2 'PreReleaseTest'
+    Install-ModuleFast @imfParams 'PreReleaseTest' -DestinationOnly -PassThru | Should -HaveCount 1
+    Install-ModuleFast @imfParams 'PreReleaseTest' -DestinationOnly -PassThru | Should -BeNullOrEmpty
+  }
+
   It 'Errors trying to install prerelease over regular module' {
     Install-ModuleFast @imfParams 'PrereleaseTest=0.0.1'
     { Install-ModuleFast @imfParams 'PrereleaseTest=0.0.1-prerelease' }


### PR DESCRIPTION
Fixes #45

This pull request fixes an issue with the `Install-ModuleFast` function where it doesn't install modules in the specified destination if the same module is already installed in a different location on the system.

To address this issue, I have added a new parameter `-DestinationOnly` to the `Install-ModuleFast` function. When this parameter is specified, the function will only consider the specified destination and not any other paths currently in the `PSModulePath`. This is useful for scenarios where you want to ensure that the modules are installed in a specific location, such as in a CI environment.

I have also made changes to the `Get-ModuleFastPlan` and `Find-LocalModule` functions to support the new `-DestinationOnly` parameter.