### PR TITLE
✨ Support for PSResourceGet, RequiredModules, and PSDepend manifest files

### DIFF
--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -581,6 +581,14 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     $modulesToInstall = Install-ModuleFast @imfParams -Path $specFilePath -Plan
     #TODO: Verify individual modules and versions
     $modulesToInstall | Should -Not -BeNullOrEmpty
+    if ($modules) {
+      foreach ($module in $modules) {
+        $module | Should -BeIn $modulesToInstall
+        $modulesToInstall.Remove($module)
+      }
+      #All modules should be removed at this point
+      $modulesToInstall | Should -BeNullOrEmpty
+    }
   } -TestCases @(
     @{
       Name = 'PowerShell Data File'
@@ -605,6 +613,14 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     @{
       Name = 'DynamicManifest'
       File = 'Dynamic.psd1'
+    },
+    @{
+      Name = 'ModuleBuilder'
+      File = 'ModuleBuilder-RequiredModules.psd1'
+    },
+    @{
+      Name = 'PSDepend-Implicit'
+      File = 'PSDepend.psd1'
     }
   )
 

--- a/Test/Mocks/ModuleBuilder-RequiredModules.psd1
+++ b/Test/Mocks/ModuleBuilder-RequiredModules.psd1
@@ -1,0 +1,12 @@
+# NOTE: follow nuget syntax for versions: https://docs.microsoft.com/en-us/nuget/reference/package-versioning#version-ranges-and-wildcards
+@{
+	'Configuration'    = '[1.3.1,2.0)'
+	'ModuleBuilder'    = '1.*'
+	'Pester'           = '[4.10.1,5.0)'
+	'PowerShellGet'    = '2.0.4'
+	'PSScriptAnalyzer' = '1.*'
+	'ImportExcel'      = @{
+		Version    = '7.*'
+		Repository = 'https://www.powershellgallery.com/api/v2'
+	}
+}

--- a/Test/Mocks/PSDepend.psd1
+++ b/Test/Mocks/PSDepend.psd1
@@ -1,0 +1,33 @@
+@{
+	psdeploy                                = 'latest'
+	psake                                   = 'latest'
+	Pester                                  = 'latest'
+	BuildHelpers                            = '0.0.20'  # I don't trust this Warren guy...
+	'PSGalleryModule::InvokeBuild'          = 'latest'
+	'GitHub::RamblingCookieMonster/PSNeo4j' = 'master'
+	'RamblingCookieMonster/PowerShell'      = 'master'
+	buildhelpers_0_0_20                     = @{
+		Name           = 'buildhelpers'
+		DependencyType = 'PSGalleryModule'
+		Parameters     = @{
+			Repository         = 'PSGallery'
+			SkipPublisherCheck = $true
+		}
+		Version        = '0.0.20'
+		Tags           = 'prod', 'test'
+		PreScripts     = 'C:\RunThisFirst.ps1'
+		DependsOn      = 'some_task'
+	}
+
+	some_task                               = @{
+		DependencyType = 'task'
+		Target         = 'C:\RunThisFirst.ps1'
+		DependsOn      = 'nuget'
+	}
+
+	nuget                                   = @{
+		DependencyType = 'FileDownload'
+		Source         = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
+		Target         = 'C:\nuget.exe'
+	}
+}


### PR DESCRIPTION
The `-Path` parameter can now be directed to a manifest .psd1 or .json file of these alternate specification formats and ModuleFast will resolve and install the packages. 

ModuleFast has some limited autodetection for the format used, but in case it guesses wrong, there is also a new `-SpecFileType` parameter to explicitly define which format the file is in. Check the debug messages to see which format it detected and why.