### PR TITLE
🐛 Make CurrentUser work properly and ignore profile setup

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -28,6 +28,10 @@ $SCRIPT:DefaultSource = 'https://pwsh.gallery/index.json'
 
 #region Public
 
+enum InstallScope {
+  CurrentUser
+}
+
 function Install-ModuleFast {
   <#
   .SYNOPSIS
@@ -232,7 +236,9 @@ function Install-ModuleFast {
     #Outputs the installation plan of modules not already available and needing to be installed to the pipeline as well as the console. This can be saved and provided to Install-ModuleFast at a later date. This is functionally the same as -WhatIf but without the additional WhatIf Output
     [Switch]$Plan,
     #This will output the resulting modules that were installed.
-    [Switch]$PassThru
+    [Switch]$PassThru,
+    #Setting this to "CurrentUser" is the same as specifying the destination as 'Current'. This is a usability convenience.
+    [InstallScope]$Scope
   )
   begin {
     trap {$PSCmdlet.ThrowTerminatingError($PSItem)}
@@ -248,6 +254,9 @@ function Install-ModuleFast {
       Clear-ModuleFastCache
     }
 
+    if ($Scope -eq [InstallScope]::CurrentUser) {
+      $Destination = 'CurrentUser'
+    }
     if (-not $Destination) {
       $Destination = $defaultRepoPath
     } elseif ($IsWindows -and $Destination -eq 'CurrentUser') {

--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -140,7 +140,7 @@ function Install-ModuleFast {
   Installs a specific version of ImportExcel using
 
   .EXAMPLE
-  Install-ModuleFast 'ImportExcel' -Destination 'CurrentUser' -NoProfileUpdate -NoPSModulePathUpdate
+  Install-ModuleFast 'ImportExcel' -Destination 'CurrentUser'
 
   Installs ImportExcel to the legacy PowerShell Modules folder in My Documents on Windows only, but does not update the PSModulePath or the user profile to include the new module path. This behavior is similar to Install-Module or Install-PSResource.
 
@@ -240,6 +240,9 @@ function Install-ModuleFast {
     # Setup the Destination repository
     $defaultRepoPath = $(Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'powershell/Modules')
 
+    # Get the current PSModulePath
+    $PSModulePaths = $env:PSModulePath.Split([Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
+
     #Clear the ModuleFastCache if -Update is specified to ensure fresh lookups of remote module availability
     if ($Update) {
       Clear-ModuleFastCache
@@ -250,6 +253,10 @@ function Install-ModuleFast {
     } elseif ($IsWindows -and $Destination -eq 'CurrentUser') {
       $windowsDefaultDocumentsPath = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'PowerShell/Modules'
       $Destination = $windowsDefaultDocumentsPath
+      # if CurrentUser and is on Windows, we do not need to update the PSModulePath or the user profile.
+      # this allows for a similar experience to Install-Module and Install-PSResource
+      $NoPSModulePathUpdate = $true
+      $NoProfileUpdate = $true
     }
 
     # Autocreate the default as a convenience, otherwise require the path to be present to avoid mistakes

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -545,6 +545,27 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     Install-ModuleFast @imfParams 'PreReleaseTest' -DestinationOnly -PassThru | Should -BeNullOrEmpty
   }
 
+  #TODO: Possibly mock this so we don't touch the testing system documents directory
+  It 'Destination CurrentUser installs to $HOME\Documents\PowerShell\Modules' {
+    try {
+      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
+      Install-ModuleFast @imfParams 'PrereleaseTest' -Destination CurrentUser
+      Resolve-Path $HOME\Documents\PowerShell\Modules\PrereleaseTest -EA Stop
+    } finally {
+      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'Scope CurrentUser installs to $HOME\Documents\PowerShell\Modules' {
+    try {
+      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
+      Install-ModuleFast @imfParams 'PrereleaseTest' -Scope CurrentUser
+      Resolve-Path $HOME\Documents\PowerShell\Modules\PrereleaseTest -EA Stop
+    } finally {
+      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+
   It '-DestinationOnly works on modules with dependencies' {
     Install-ModuleFast @imfParams 'Az.Compute' -DestinationOnly -PassThru | Should -HaveCount 2
   }


### PR DESCRIPTION
`-Scope CurrentUser` has been added to mimic the Install-Module behavior, and the automatic profile setup is excluded when done on Windows.

Fixes #64 
