### PR TITLE
:white_check_mark: update dependency test name and target version

### DIFF
--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -361,8 +361,8 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
   It 'Gets Module with 1 dependency' {
     Get-ModuleFastPlan 'Az.Compute' | Should -HaveCount 2
   }
-  It 'Gets Module with lots of dependencies (Az)' {
-    Get-ModuleFastPlan @{ModuleName = 'Az'; ModuleVersion = '11.0' } | Should -HaveCount 86
+  It 'Gets all dependencies for a Module with lots of dependencies (Az)' {
+    Get-ModuleFastPlan @{ModuleName = 'Az'; ModuleVersion = '11.0.0' } | Should -HaveCount 86
   }
   It 'Gets Module with 4 section version number and a 4 section version number dependency (VMware.VimAutomation.Common)' {
     Get-ModuleFastPlan 'VMware.VimAutomation.Common' | Should -HaveCount 2


### PR DESCRIPTION
As suggested at PS Summit, rename the test to have a clearer name and lock down version so the expected number doesn't need to be updated everytime Az release a new selection of modules. 