### PR TITLE
fixes #89, check powershell.config.json for PSModulePath

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -37,6 +37,7 @@ $SCRIPT:DefaultSource = 'https://pwsh.gallery/index.json'
 
 enum InstallScope {
   CurrentUser
+  AllUsers
 }
 
 
@@ -254,41 +255,36 @@ function Install-ModuleFast {
   begin {
     trap {$PSCmdlet.ThrowTerminatingError($PSItem)}
 
-    $CustomPSModulePath = Get-CustomPSModulePath
-    # Setup the Destination repository
-    $defaultRepoPath = $(Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'powershell/Modules')
 
-    # Get the current PSModulePath
-    $PSModulePaths = $env:PSModulePath.Split([Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
 
     #Clear the ModuleFastCache if -Update is specified to ensure fresh lookups of remote module availability
     if ($Update) {
       Clear-ModuleFastCache
     }
 
-    if ($Scope -eq [InstallScope]::CurrentUser) {
-      $Destination = 'CurrentUser'
-    }
+    $defaultRepoPath = $(Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) 'powershell/Modules')
     if (-not $Destination) {
-      $Destination =
-      if ($CustomPSModulePath) {
-          $CustomPSModulePath
+      #Special function that will retrieve the default module path for the current user
+      $Destination = Get-PSDefaultModulePath -AllUsers:($Scope -eq 'AllUsers')
+
+      #Special case for Windows to avoid the default installation path because it has issues with OneDrive
+      $defaultWindowsModulePath = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'PowerShell/Modules'
+      if ($IsWindows -and $Destination -eq $defaultWindowsModulePath -and $Scope -ne 'CurrentUser') {
+        Write-Debug "Windows Documents module folder detected. Changing to $defaultRepoPath"
+        $Destination = $defaultRepoPath
       }
-      else {
-          $defaultRepoPath
-      }
-    } elseif ($IsWindows -and $Destination -eq 'CurrentUser') {
-      $windowsDefaultDocumentsPath = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'PowerShell/Modules'
-      $Destination = $windowsDefaultDocumentsPath
-      # if CurrentUser and is on Windows, we do not need to update the PSModulePath or the user profile.
-      # this allows for a similar experience to Install-Module and Install-PSResource
-      $NoPSModulePathUpdate = $true
-      $NoProfileUpdate = $true
     }
 
-    # Autocreate the default as a convenience, otherwise require the path to be present to avoid mistakes
-    if ($Destination -eq $defaultRepoPath -and -not (Test-Path $Destination)) {
-      if (Approve-Action 'Create Destination Folder' $Destination) {
+    if (-not $Destination) {
+      throw 'Failed to determine destination path. This is a bug, please report it, it should always have something by this point.'
+    }
+
+    # Require approval to create the destination folder if it is not our default path, otherwise this is automatic
+    if (-not (Test-Path $Destination)) {
+      if ($configRepoPath -or
+          $Destination -eq $defaultRepoPath -or
+          (Approve-Action 'Create Destination Folder' $Destination)
+      ) {
         New-Item -ItemType Directory -Path $Destination -Force | Out-Null
       }
     }
@@ -296,19 +292,13 @@ function Install-ModuleFast {
     $Destination = Resolve-Path $Destination
 
     if (-not $NoPSModulePathUpdate) {
-      if ($defaultRepoPath -ne $Destination -and $Destination -notin $PSModulePaths) {
-        Write-Warning 'Parameter -Destination is set to a custom path not in your current PSModulePath. We will add it to your PSModulePath for this session. You can suppress this behavior with the -NoPSModulePathUpdate switch.'
-        $NoProfileUpdate = $true
-      }
+      # Get the current PSModulePath
+      $PSModulePaths = $env:PSModulePath.Split([Path]::PathSeparator, [StringSplitOptions]::RemoveEmptyEntries)
 
-      $addToPathParams = @{
-        Destination     = $Destination
-        NoProfileUpdate = $NoProfileUpdate
+      #Only update if the module path is not already in the PSModulePath
+      if ($Destination -notin $PSModulePaths) {
+        Add-DestinationToPSModulePath -Destination $Destination -NoProfileUpdate:$NoProfileUpdate -Confirm:$Confirm
       }
-      if ($PSBoundParameters.ContainsKey('Confirm')) {
-        $addToPathParams.Confirm = $PSBoundParameters.Confirm
-      }
-      Add-DestinationToPSModulePath @addtoPathParams
     }
 
     #We want to maintain a single HttpClient for the life of the module. This isn't as big of a deal as it used to be but
@@ -2166,36 +2156,25 @@ function Approve-Action {
 
   return $ThisCmdlet.ShouldProcess($Target, $Action)
 }
-function Get-CustomPSModulePath {
-  <#
-  .DESCRIPTION
-  Gets the custom PSModulePath from the powershell.config.json file in the user's profile directory or $PSHOME.
-  user profile is preferred over global profile.
-  .PARAMETER Config
-  The path to the powershell.config.json file. If not specified, it will default to the user's profile directory.
-  this should only be used in testing scenarios.
-  #>
-    [cmdletbinding()]
-    param(
-      [String] $Config
-    )
-    if (-Not $Config) {
-      $Config = Join-Path (Split-Path $PROFILE.CurrentUserCurrentHost) 'powershell.config.json'
-    }
-    if (Test-Path -Path $Config -PathType Leaf) {
-        $json = Get-Content -LiteralPath $Config -Raw | ConvertFrom-Json
-        $LocalPSModulePath = ${json}?.PSModulePath
-        if (-Not [String]::IsNullOrEmpty($LocalPSModulePath)) {
-            return $LocalPSModulePath
-        }
-    }
-    $GlobalConfig = Join-Path $PSHOME 'powershell.config.json'
-    if (Test-Path -Path $GlobalConfig -PathType Leaf) {
-        $json = Get-Content -LiteralPath $globalconfig -Raw | ConvertFrom-Json
-        $GlobalPSModulePath = ${json}?.PSModulePath
-        if (-Not [String]::IsNullOrEmpty($GlobalPSModulePath)) {
-            $GlobalPSModulePath
-        }
+
+#Fetches the module path for the current user or all users.
+#HACK: Uses a private API until https://github.com/PowerShell/PowerShell/issues/15552 is resolved
+function Get-PSDefaultModulePath ([Switch]$AllUsers) {
+    $scopeType = [Management.Automation.Configuration.ConfigScope]
+    $pscType = $scopeType.
+    Assembly.
+    GetType('System.Management.Automation.Configuration.PowerShellConfig')
+
+    $pscInstance = $pscType.
+    GetField('Instance', [Reflection.BindingFlags]'Static,NonPublic').
+    GetValue($null)
+
+    $getModulePathMethod = $pscType.GetMethod('GetModulePath', [Reflection.BindingFlags]'Instance,NonPublic')
+
+    if ($AllUsers) {
+        $getModulePathMethod.Invoke($pscInstance, $scopeType::AllUsers) ?? [Management.Automation.ModuleIntrinsics]::GetPSModulePath('BuiltIn')
+    } else {
+        $getModulePathMethod.Invoke($pscInstance, $scopeType::CurrentUser) ?? [Management.Automation.ModuleIntrinsics]::GetPSModulePath('User')
     }
 }
 

--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -2189,7 +2189,7 @@ function Get-CustomPSModulePath {
             return $LocalPSModulePath
         }
     }
-    $GlobalConfig = "$PSHOME\powershell.config.json"
+    $GlobalConfig = Join-Path $PSHOME 'powershell.config.json'
     if (Test-Path -Path $GlobalConfig -PathType Leaf) {
         $json = Get-Content -LiteralPath $globalconfig -Raw | ConvertFrom-Json
         $GlobalPSModulePath = ${json}?.PSModulePath

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -72,6 +72,16 @@ InModuleScope 'ModuleFast' {
       }
     }
   }
+  Describe 'Custom Module Path' {
+    It 'Should respect powershell.config.json PSModulePath' {
+      $jsonconfig = New-TemporaryFile
+      $CustomPSModulePath = Join-Path (Split-Path $jsonconfig -Parent) -ChildPath 'CustomPSModulePath'
+        [PSCustomObject]@{
+          PSModulePath = $CustomPSModulePath
+        } | ConvertTo-Json | Set-Content $jsonconfig
+        Get-CustomPSModulePath $jsonconfig | Should -Be $CustomPSModulePath
+    }
+  }
 
   Describe 'Import-ModuleManifest' {
     It 'Reads Dynamic Manifest' {
@@ -770,4 +780,3 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
     }
   }
 }
-

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -72,16 +72,6 @@ InModuleScope 'ModuleFast' {
       }
     }
   }
-  Describe 'Custom Module Path' {
-    It 'Should respect powershell.config.json PSModulePath' {
-      $jsonconfig = New-TemporaryFile
-      $CustomPSModulePath = Join-Path (Split-Path $jsonconfig -Parent) -ChildPath 'CustomPSModulePath'
-        [PSCustomObject]@{
-          PSModulePath = $CustomPSModulePath
-        } | ConvertTo-Json | Set-Content $jsonconfig
-        Get-CustomPSModulePath $jsonconfig | Should -Be $CustomPSModulePath
-    }
-  }
 
   Describe 'Import-ModuleManifest' {
     It 'Reads Dynamic Manifest' {
@@ -564,19 +554,17 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
 
   #TODO: Possibly mock this so we don't touch the testing system documents directory
   It 'Destination CurrentUser installs to $HOME\Documents\PowerShell\Modules' {
+    if (-not $profile) {
+      Set-ItResult -Skipped -Because 'This test is not supported when $profile is not set'
+    }
+    $winConfigPath = Join-Path (Split-Path ($profile.CurrentUserAllHosts)) 'powershell.config.json'
+    if (-not $IsWindows -or (Test-Path $winConfigPath)) {
+      Set-ItResult -Skipped -Because 'This test is not supported on non-Windows or when powershell.config.json is present'
+    }
+
     try {
       Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
       Install-ModuleFast @imfParams 'PrereleaseTest' -Destination CurrentUser
-      Resolve-Path $HOME\Documents\PowerShell\Modules\PrereleaseTest -EA Stop
-    } finally {
-      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
-    }
-  }
-
-  It 'Scope CurrentUser installs to $HOME\Documents\PowerShell\Modules' {
-    try {
-      Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
-      Install-ModuleFast @imfParams 'PrereleaseTest' -Scope CurrentUser
       Resolve-Path $HOME\Documents\PowerShell\Modules\PrereleaseTest -EA Stop
     } finally {
       Remove-Item $HOME\Documents\PowerShell\Modules\PrereleaseTest -Recurse -Force -ErrorAction SilentlyContinue
@@ -766,7 +754,15 @@ Describe 'Install-ModuleFast' -Tag 'E2E' {
 
   Describe 'GitHub Packages' {
     It 'Gets Specific Module' {
+      if (-not (Get-Command Get-Secret -ea 0)) {
+        Set-ItResult -Skipped -Because 'SecretManagement Not Present'
+        return
+      }
       $credential = [PSCredential]::new('Pester', (Get-Secret -Name 'ReadOnlyPackagesGithubPAT'))
+      if (-not $credential) {
+        Set-ItResult -Skipped -Because 'No ReadOnlyPackagesGithubPAT Credential'
+        return
+      }
       $actual = Install-ModuleFast @imfParams -Specification 'PrereleaseTest=0.0.1' -Source 'https://nuget.pkg.github.com/justingrote/index.json' -Credential $credential -Plan
       $actual.Name | Should -Be 'PrereleaseTest'
       $actual.ModuleVersion | Should -Be '0.0.1'


### PR DESCRIPTION
added helper function to check `powershell.config.json` for `PSModulePath`.

it will only use that when `-Destination` is not present.
