### PR TITLE
🐛 Fix blob storage extra slash

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -1654,7 +1654,7 @@ function Get-ModuleInfoAsync {
     | Sort-Object -Property '@type' -Descending
     | Select-Object -ExpandProperty '@id' -First 1
 
-    $Uri = "$registrationBase/$($ModuleId.ToLower())/$Path"
+    $Uri = "$($registrationBase -replace '/$','')/$($ModuleId.ToLower())/$Path"
   }
 
   $requestTask = $SCRIPT:RequestCache[$Uri]


### PR DESCRIPTION
Resolves an issue where feeds that provide a trailing slash on their repositories and are strict on slashes (Azure Blob Storage) wouldn't resolve correctly.