### PR TITLE
✨ Exclude Prereleases from Exclusive Matching

### DIFF
--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -1603,7 +1603,7 @@ class ModuleFastSpec {
       ($max.Patch -eq $Version.Patch)
     )
     {
-      Write-Verbose "ModuleFastSpec: $this is being compared to $Version. We are excluding this prerelease for ease of use as it is assumed you did not want prereleases when specifying a major-exclusive release. Specify -StrictSemVer to override this behavior."
+      Write-Verbose "ModuleFastSpec: $this is being compared to $Version. We are excluding this prerelease for ease of use as it is assumed you did not want prereleases when specifying a max exclusive bound. Specify -StrictSemVer to override this behavior."
       return $false
     }
 

--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -1603,7 +1603,7 @@ class ModuleFastSpec {
       ($max.Patch -eq $Version.Patch)
     )
     {
-      Write-Verbose "ModuleFastSpec: $this is being compared to $Version. We are excluding this prerelease for ease of use as it is assumed you did not want prereleases when specifying a max exclusive bound. Specify -StrictSemVer to override this behavior."
+      Write-Verbose "ModuleFastSpec: $this is being compared to $Version. We are excluding this prerelease for ease of use as it is assumed you did not want prereleases when specifying an exclusive upper bound. Specify -StrictSemVer to override this behavior."
       return $false
     }
 

--- a/ModuleFast.psm1
+++ b/ModuleFast.psm1
@@ -1618,7 +1618,7 @@ class ModuleFastSpec {
         return $strictSatisfies
       }
 
-      Write-Verbose "ModuleFastSpec: $this is being compared to $Version. We are excluding this prerelease for ease of use as it is assumed you did not want prereleases when specifying an exclusive upper bound. Specify -StrictSemVer to override this behavior."
+      Write-Verbose "ModuleFastSpec: $this is typically satisfied by $Version, but this prerelease of the exclusive maximum version specification was ignored for ease of use. Specify -StrictSemVer to allow pre-releases of excluded versions."
       return $false
     }
 

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -252,10 +252,10 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
           ModuleName = 'PrereleaseTest'
         },
         @{
-          Spec       = 'PrereleaseTest!<0.0.1'
+          Spec       = 'PrereleaseTest!<=0.0.1'
           Check      = {
             $actual.Name | Should -Be 'PrereleaseTest'
-            $actual.ModuleVersion | Should -Be '0.0.1-prerelease'
+            $actual.ModuleVersion | Should -Be '0.0.1'
           }
           ModuleName = 'PrereleaseTest'
         },
@@ -278,6 +278,22 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
             $actual.ModuleVersion | Should -Be '1.99.0' #Nuget changes this to 1.99
           }
         },
+        # Special cases where the upper bound is specified as exclusive, ignore prereleases
+        @{
+          Spec       = 'PrereleaseTest!<0.0.2'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            $actual.ModuleVersion | Should -Be '0.0.1' #Install module version is 0.4.15.0 but nuget truncates this
+          }
+        },
+        @{
+          Spec       = 'PrereleaseTest!<=0.0.2'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            $actual.ModuleVersion | Should -Be '0.0.2-prerelease' #Install module version is 0.4.15.0 but nuget truncates this
+          }
+        },
+        #End special cases
         @{
           Spec       = 'PnP.PowerShell:2.2.*'
           ModuleName = 'PnP.PowerShell'

--- a/ModuleFast.tests.ps1
+++ b/ModuleFast.tests.ps1
@@ -159,6 +159,21 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
       } -TestCases $moduleSpecTestCases
     }
 
+    Context 'StrictSemVer Parameter' {
+      It 'StrictSemVer matches prereleases with exclusive upper bound' {
+        $actual = Get-ModuleFastPlan 'PrereleaseTest!<0.0.2' -StrictSemVer
+        $actual | Should -HaveCount 1
+        $actual.ModuleVersion.IsPrerelease | Should -Be $true
+        $actual.ModuleVersion.Patch | Should -Be 2
+      }
+      It 'StrictSemVer not specified does not match prereleases with exclusive upper bound' {
+        $actual = Get-ModuleFastPlan 'PrereleaseTest!<0.0.2'
+        $actual | Should -HaveCount 1
+        $actual.ModuleVersion.IsPrerelease | Should -Be $false
+        $actual.ModuleVersion.Patch | Should -Be 1
+      }
+    }
+
     Context 'ModuleFastSpec String' {
       $stringTestCases = (
         @{
@@ -283,14 +298,43 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
           Spec       = 'PrereleaseTest!<0.0.2'
           ModuleName = 'PrereleaseTest'
           Check      = {
-            $actual.ModuleVersion | Should -Be '0.0.1' #Install module version is 0.4.15.0 but nuget truncates this
+            $actual.ModuleVersion | Should -Be '0.0.1'
           }
         },
         @{
           Spec       = 'PrereleaseTest!<=0.0.2'
           ModuleName = 'PrereleaseTest'
           Check      = {
-            $actual.ModuleVersion | Should -Be '0.0.2-prerelease' #Install module version is 0.4.15.0 but nuget truncates this
+            $actual.ModuleVersion | Should -Be '0.0.2-prerelease'
+          }
+        },
+        @{
+          # Test lexical matching. This should not match the 'prerelease' version because r is after p
+          Spec       = 'PrereleaseTest!:(0.0.2-rIsAfterP,0.0.2)'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            [string]$actual | Should -Match 'a matching module was not found'
+          }
+        },
+        @{
+          Spec       = 'PrereleaseTest!<0.0.2-prerelease'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            [string]$actual.ModuleVersion | Should -Be '0.0.2-newerversion'
+          }
+        },
+        @{
+          Spec       = 'PrereleaseTest!:(0.0.2-alpha,0.0.2)'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            [string]$actual.ModuleVersion | Should -Be '0.0.2-prerelease'
+          }
+        },
+        @{
+          Spec       = 'PrereleaseTest!:(0.0.2-alpha,0.0.2-prerelease)'
+          ModuleName = 'PrereleaseTest'
+          Check      = {
+            [string]$actual.ModuleVersion | Should -Be '0.0.2-newerversion'
           }
         },
         #End special cases
@@ -316,18 +360,27 @@ Describe 'Get-ModuleFastPlan' -Tag 'E2E' {
       }
 
       It 'Gets Module with String Parameter: <Spec>' {
-        $actual = Get-ModuleFastPlan $Spec
-        $actual | Should -HaveCount 1
-        $ModuleName | Should -Be $actual.Name
-        $actual.ModuleVersion | Should -Not -BeNullOrEmpty
+        try {
+          $actual = Get-ModuleFastPlan $Spec
+          $actual | Should -HaveCount 1
+          $ModuleName | Should -Be $actual.Name
+          $actual.ModuleVersion | Should -Not -BeNullOrEmpty
+        } catch {
+          $actual = $PSItem
+        }
         if ($Check) { . $Check }
+
       } -TestCases $stringTestCases
 
       It 'Gets Module with String Pipeline: <Spec>' {
-        $actual = $Spec | Get-ModuleFastPlan
-        $actual | Should -HaveCount 1
-        $ModuleName | Should -Be $actual.Name
-        $actual.ModuleVersion | Should -Not -BeNullOrEmpty
+        try {
+          $actual = $Spec | Get-ModuleFastPlan
+          $actual | Should -HaveCount 1
+          $ModuleName | Should -Be $actual.Name
+          $actual.ModuleVersion | Should -Not -BeNullOrEmpty
+        } catch {
+          $actual = $PSItem
+        }
         if ($Check) { . $Check }
       } -TestCases $stringTestCases
     }

--- a/README.MD
+++ b/README.MD
@@ -89,6 +89,8 @@ For more information about NuGet version range syntax used with the ':' operator
 
 ModuleFast also fully supports the [ModuleSpecification object and hashtable-like string syntaxes](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7.5#-modules-module-name--hashtable) that are used by Install-Module and Install-PSResource. More information on this format: https://learn.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.modulespecification?view=powershellsdk-7.4.0
 
+NOTE: ModuleFast does not strictly conform to SemVer without the `-StrictSemVer` parameter. For example, for ergonomics, we exclude 2.0 prereleases from `Module<2.0`, since most people who do this do not want 2.0 prereleases which might contain breaking changes, even though by semver definition, `Module 2.0-alpha1` is less than 2.0
+
 ## Logging
 ModuleFast has extensive Verbose and Debug information available if you specify the -Verbose and/or -Debug parameters. This can be useful for troubleshooting or understanding how ModuleFast is working. Verbose level provides a high level "what" view of the process of module selection, while Debug level provides a much more detailed "Why" information about the module selection and installation process that can be useful in troubleshooting issues.
 


### PR DESCRIPTION
Modifies behavior so that `Module<2.0` does not match `2.0.0-alpha1` unless `-StrictSemVer` is specified
Fixes #107
![image](https://github.com/user-attachments/assets/b32dd608-2997-4fef-a038-c4cf903c2865)